### PR TITLE
Add npm download metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore generated credentials from google-github-actions/auth
 gha-creds-*.json
+.idea

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ socket_score{package="@celo/0x-contracts",score="miscellaneous",version="2.1.2-0
 socket_score{package="@celo/0x-contracts",score="quality",version="2.1.2-0.0"} 0.6410426253533731
 socket_score{package="@celo/0x-contracts",score="supplychainrisk",version="2.1.2-0.0"} 0.39592272547306173
 socket_score{package="@celo/0x-contracts",score="vulnerability",version="2.1.2-0.0"} 0.25
+# HELP npm_download_count NPM package download count for a given day
+# TYPE npm_download_count gauge
+npm_download_count{date="2024-02-18",package="@celo/0x-contracts"} 180
 ...
 ```
 
@@ -25,6 +28,7 @@ socket_score{package="@celo/0x-contracts",score="vulnerability",version="2.1.2-0
 - `PERIOD`: The period to refresh the [Socket.dev](https://socket.dev/) scores, in hours. If not set, defaults to `24`.
 - `TIMEOUT`: The timeout for requests to [Socket.dev](https://socket.dev/), in seconds. If not set, defaults to `15`.
 - `RETRIES`: The number of retries for requests to [Socket.dev](https://socket.dev/). If not set, defaults to `5`.
+- `MAX_PACKAGES`: The maximum number of packages to fetch metrics for. If not set, limit is removed and all packages processed.
 
 ## Tests
 

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ var initializing bool = true
 
 var retries int
 var timeout time.Duration
+var maxPackages = -1
 
 var exportedMetrics = []Metric{}
 
@@ -151,8 +152,9 @@ func fetchMetrics() ([]Metric, error) {
 	celoPackages := npmResponse.Objects
 	var socketAPI = NewSocketAPI(token)
 
-	//debug: remove me
-	celoPackages = celoPackages[0:5]
+	if maxPackages > 0 {
+		celoPackages = celoPackages[0:maxPackages]
+	}
 
 	for _, object := range celoPackages {
 		var currentPackage = object.Package
@@ -253,6 +255,20 @@ func initializeConfig() {
 			os.Exit(1)
 		}
 		timeout = time.Duration(timeoutInt) * time.Second
+	}
+
+	maxPackagesEnvVar, ok := os.LookupEnv("MAX_PACKAGES")
+	if !ok {
+		logrus.Error("Could not read env. var. MAX_PACKAGES. Deactivating")
+		maxPackages = -1
+	} else {
+		maxPackagesInt, err := strconv.Atoi(maxPackagesEnvVar)
+		if err != nil {
+			logrus.Error(fmt.Sprintf("Could not parse TIMEOUT env. var. to int: %s", err))
+			maxPackages = -1
+		}
+
+		maxPackages = maxPackagesInt
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var initializing bool = true
+var initializing = true
 
 var retries int
 var timeout time.Duration
@@ -103,12 +103,12 @@ func (collector *socketCollector) Collect(ch chan<- prometheus.Metric) {
 
 func (s *SocketResponse) ToMetrics(packageName string, packageVersion string) []Metric {
 	metrics := []Metric{
-		Metric{"score": "supplychainrisk", "value": s.Supplychainrisk.Score},
-		Metric{"score": "quality", "value": s.Quality.Score},
-		Metric{"score": "maintenance", "value": s.Maintenance.Score},
-		Metric{"score": "vulnerability", "value": s.Vulnerability.Score},
-		Metric{"score": "license", "value": s.License.Score},
-		Metric{"score": "miscellaneous", "value": s.Miscellaneous.Score},
+		{"score": "supplychainrisk", "value": s.Supplychainrisk.Score},
+		{"score": "quality", "value": s.Quality.Score},
+		{"score": "maintenance", "value": s.Maintenance.Score},
+		{"score": "vulnerability", "value": s.Vulnerability.Score},
+		{"score": "license", "value": s.License.Score},
+		{"score": "miscellaneous", "value": s.Miscellaneous.Score},
 	}
 
 	for _, metric := range metrics {
@@ -122,7 +122,7 @@ func (s *SocketResponse) ToMetrics(packageName string, packageVersion string) []
 
 func (npm *NpmDownloadCountResponse) ToMetrics(packageName string) []Metric {
 	return []Metric{
-		Metric{"package": packageName, "downloads": npm.GetDownloads(), "date": npm.End, "_type": "npm_download"},
+		{"package": packageName, "downloads": npm.GetDownloads(), "date": npm.End, "_type": "npm_download"},
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -139,6 +139,9 @@ func fetchMetrics() ([]Metric, error) {
 	celoPackages := npmResponse.Objects
 	var socketAPI = NewSocketAPI(token)
 
+	//debug: remove me
+	celoPackages = celoPackages[0:5]
+
 	for _, object := range celoPackages {
 		var currentPackage = object.Package
 
@@ -158,7 +161,7 @@ func fetchMetrics() ([]Metric, error) {
 			continue
 		}
 
-		packageDownloadMetrics := downloadResponse.ToMetrics(currentPackage.Name, currentPackage.Version)
+		packageDownloadMetrics := downloadResponse.ToMetrics(currentPackage.Name)
 		result = append(result, packageDownloadMetrics...)
 	}
 

--- a/main.go
+++ b/main.go
@@ -15,8 +15,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var initializing = true
-
 var retries int
 var timeout time.Duration
 var maxPackages = -1
@@ -59,6 +57,7 @@ func (collector *socketCollector) Describe(ch chan<- *prometheus.Desc) {
 
 	//Update this section with the each metric you create for a given collector
 	ch <- collector.socketMetric
+	ch <- collector.downloadMetric
 }
 
 // Collect implements required collect function for all promehteus collectors
@@ -66,7 +65,7 @@ func (collector *socketCollector) Collect(ch chan<- prometheus.Metric) {
 	logrus.Debug("Received HTTP request")
 	//Implement logic here to determine proper metric value to return to prometheus
 	//for each descriptor or call other functions that do so.
-	logrus.Debug(fmt.Sprintf("Sending metrics to Prometheus channel"))
+	logrus.Debug("Sending metrics to Prometheus channel")
 	for _, metric := range exportedMetrics {
 		if metric["_type"] == "socket_score" {
 			s, err := strconv.ParseFloat(fmt.Sprintf("%v", metric["value"]), 64)
@@ -264,7 +263,7 @@ func initializeConfig() {
 	} else {
 		maxPackagesInt, err := strconv.Atoi(maxPackagesEnvVar)
 		if err != nil {
-			logrus.Error(fmt.Sprintf("Could not parse TIMEOUT env. var. to int: %s", err))
+			logrus.Error(fmt.Sprintf("Could not parse MAX_PACKAGES env. var. to int: %s", err))
 			maxPackages = -1
 		}
 

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func newSocketCollector() *socketCollector {
 		),
 		downloadMetric: prometheus.NewDesc("npm_download_count",
 			"NPM package download count for a given day",
-			[]string{"package", "date"}, nil,
+			[]string{"package"}, nil,
 		),
 	}
 }
@@ -94,7 +94,6 @@ func (collector *socketCollector) Collect(ch chan<- prometheus.Metric) {
 				prometheus.GaugeValue,
 				s,
 				fmt.Sprintf("%v", metric["package"]),
-				fmt.Sprintf("%v", metric["date"]),
 			)
 		}
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -31,7 +31,13 @@ var ch = make(chan prometheus.Metric)
 // Count that the number of metrics is greater than 1
 func TestCollectAndCount(t *testing.T) {
 
-	fetchMetrics()
+	maxPackages = 5
+	metrics, err := fetchMetrics()
+	if err != nil {
+		t.Fatalf("Metric collection failed %e", err)
+	}
+
+	exportedMetrics = metrics
 
 	number := testutil.CollectAndCount(collector, "socket_score")
 	if number < 1 {

--- a/main_test.go
+++ b/main_test.go
@@ -31,7 +31,7 @@ var ch = make(chan prometheus.Metric)
 // Count that the number of metrics is greater than 1
 func TestCollectAndCount(t *testing.T) {
 
-	updateMetrics()
+	fetchMetrics()
 
 	number := testutil.CollectAndCount(collector, "socket_score")
 	if number < 1 {

--- a/npm.go
+++ b/npm.go
@@ -32,6 +32,16 @@ type NpmDownloadCountResponse struct {
 	Downloads []NpmDownloadCounts `json:"downloads"`
 }
 
+func (npm *NpmDownloadCountResponse) GetDownloads() int {
+	if len(npm.Downloads) < 1 {
+		logrus.Errorf("Empty download count for %s", npm.Package)
+		return 0
+	}
+
+	firstDownload := npm.Downloads[0]
+	return firstDownload.Downloads
+}
+
 func GetDownloadCountForCeloNpmPackage(currentPackage NpmPackage, client *http.Client) (NpmDownloadCountResponse, error) {
 	var url = fmt.Sprintf("https://api.npmjs.org/downloads/range/last-day/@celo/%s", currentPackage.Name)
 	res, err := client.Get(url)

--- a/npm.go
+++ b/npm.go
@@ -43,15 +43,14 @@ func (npm *NpmDownloadCountResponse) GetDownloads() int {
 }
 
 func GetDownloadCountForCeloNpmPackage(currentPackage NpmPackage, client *http.Client) (NpmDownloadCountResponse, error) {
-	var url = fmt.Sprintf("https://api.npmjs.org/downloads/range/last-day/@celo/%s", currentPackage.Name)
+	var result NpmDownloadCountResponse
+	var url = fmt.Sprintf("https://api.npmjs.org/downloads/range/last-day/%s", currentPackage.Name)
 	res, err := client.Get(url)
 
 	if err != nil {
 		logrus.Errorf("Error making http request to registry.npmjs.org: %s", err)
-		return nil, err
+		return result, err
 	}
-
-	var result NpmDownloadCountResponse
 
 	err = json.NewDecoder(res.Body).Decode(&result)
 	if err != nil {
@@ -70,13 +69,13 @@ func GetCeloNPMPackages(client *http.Client) (NpmResponse, error) {
 	res, err := client.Get("https://registry.npmjs.org/-/v1/search?text=scope:celo&size=100")
 	if err != nil {
 		logrus.Errorf("Error making http request to registry.npmjs.org: %s", err)
-		return nil, err
+		return npmResponse, err
 	}
 
 	err = json.NewDecoder(res.Body).Decode(&npmResponse)
 	if err != nil {
 		logrus.Errorf("Could not decode response body from registry.npmjs.org: %s", err)
-		return nil, err
+		return npmResponse, err
 	}
 
 	return npmResponse, nil

--- a/npm.go
+++ b/npm.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"net/http"
+)
+
+type NpmPackage struct {
+	Name    string
+	Version string
+}
+
+type NpmObject struct {
+	Package NpmPackage
+}
+
+type NpmResponse struct {
+	Objects []NpmObject `json:"objects"`
+}
+
+type NpmDownloadCounts struct {
+	Downloads int    `json:"downloads"`
+	Day       string `json:"day"`
+}
+
+type NpmDownloadCountResponse struct {
+	Start     string              `json:"start"`
+	End       string              `json:"end"`
+	Package   string              `json:"package"`
+	Downloads []NpmDownloadCounts `json:"downloads"`
+}
+
+func GetDownloadCountForCeloNpmPackage(currentPackage NpmPackage, client *http.Client) (NpmDownloadCountResponse, error) {
+	var url = fmt.Sprintf("https://api.npmjs.org/downloads/range/last-day/@celo/%s", currentPackage.Name)
+	res, err := client.Get(url)
+
+	if err != nil {
+		logrus.Errorf("Error making http request to registry.npmjs.org: %s", err)
+		return nil, err
+	}
+
+	var result NpmDownloadCountResponse
+
+	err = json.NewDecoder(res.Body).Decode(&result)
+	if err != nil {
+		logrus.Errorf("Could not decode download count response body from npmjs.org: %s", err)
+		return result, err
+	}
+
+	logrus.Debugf("npm download count response: %v", result)
+
+	return result, nil
+}
+
+func GetCeloNPMPackages(client *http.Client) (NpmResponse, error) {
+	var npmResponse NpmResponse
+	logrus.Info("Sending request to registry.npmjs.org")
+	res, err := client.Get("https://registry.npmjs.org/-/v1/search?text=scope:celo&size=100")
+	if err != nil {
+		logrus.Errorf("Error making http request to registry.npmjs.org: %s", err)
+		return nil, err
+	}
+
+	err = json.NewDecoder(res.Body).Decode(&npmResponse)
+	if err != nil {
+		logrus.Errorf("Could not decode response body from registry.npmjs.org: %s", err)
+		return nil, err
+	}
+
+	return npmResponse, nil
+}

--- a/socket.go
+++ b/socket.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"net/http"
+)
+
+type SupplyChainRiskResponse struct {
+	Score float64 `json:"score"`
+}
+
+type QualityResponse struct {
+	Score float64 `json:"score"`
+}
+
+type MaintenanceResponse struct {
+	Score float64 `json:"score"`
+}
+
+type VulnerabilityResponse struct {
+	Score float64 `json:"score"`
+}
+
+type LicenseResponse struct {
+	Score float64 `json:"score"`
+}
+
+type MiscellaneousResponse struct {
+	Score float64 `json:"score"`
+}
+
+type SocketResponse struct {
+	Supplychainrisk SupplyChainRiskResponse `json:"supplyChainRisk"`
+	Quality         QualityResponse         `json:"quality"`
+	Maintenance     MaintenanceResponse     `json:"maintenance"`
+	Vulnerability   VulnerabilityResponse   `json:"vulnerability"`
+	License         LicenseResponse         `json:"license"`
+	Miscellaneous   MiscellaneousResponse   `json:"miscellaneous"`
+}
+
+type SocketAPI struct {
+	token string
+}
+
+func NewSocketAPI(token string) *SocketAPI {
+	api := new(SocketAPI)
+	api.token = token
+	return api
+}
+
+func (s SocketAPI) buildRequest(url string) *http.Request {
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("accept", "application/json")
+	req.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(s.token)))
+
+	return req
+}
+
+func (s SocketAPI) FetchSocketScores(pack NpmPackage, client *http.Client) (SocketResponse, error) {
+	var url = fmt.Sprintf("https://api.socket.dev/v0/npm/%s/%s/score", pack.Name, pack.Version)
+	var req = s.buildRequest(url)
+
+	logrus.Info(fmt.Sprintf("Requesting package %s/%s scores to api.socket.dev", pack.Name, pack.Version))
+
+	var result SocketResponse
+	res, err := client.Do(req)
+	if err != nil {
+		logrus.Error(fmt.Sprintf("Error requesting package %s to api.socket.dev: %s", pack.Name, err))
+		return result, err
+	}
+
+	err = json.NewDecoder(res.Body).Decode(&result)
+	if err != nil {
+		logrus.Error(fmt.Sprintf("Could not decode response body from api.socket.dev: %s", err))
+		return result, err
+	}
+
+	return result, nil
+}

--- a/socket.go
+++ b/socket.go
@@ -63,18 +63,18 @@ func (s SocketAPI) FetchSocketScores(pack NpmPackage, client *http.Client) (Sock
 	var url = fmt.Sprintf("https://api.socket.dev/v0/npm/%s/%s/score", pack.Name, pack.Version)
 	var req = s.buildRequest(url)
 
-	logrus.Info(fmt.Sprintf("Requesting package %s/%s scores to api.socket.dev", pack.Name, pack.Version))
+	logrus.Infof("Requesting package %s/%s scores to api.socket.dev", pack.Name, pack.Version)
 
 	var result SocketResponse
 	res, err := client.Do(req)
 	if err != nil {
-		logrus.Error(fmt.Sprintf("Error requesting package %s to api.socket.dev: %s", pack.Name, err))
+		logrus.Errorf("Error requesting package %s to api.socket.dev: %s", pack.Name, err)
 		return result, err
 	}
 
 	err = json.NewDecoder(res.Body).Decode(&result)
 	if err != nil {
-		logrus.Error(fmt.Sprintf("Could not decode response body from api.socket.dev: %s", err))
+		logrus.Errorf("Could not decode response body from api.socket.dev: %s", err)
 		return result, err
 	}
 

--- a/socket.go
+++ b/socket.go
@@ -78,5 +78,7 @@ func (s SocketAPI) FetchSocketScores(pack NpmPackage, client *http.Client) (Sock
 		return result, err
 	}
 
+	logrus.Debugf("socket.dev package score response: %v", result)
+
 	return result, nil
 }


### PR DESCRIPTION
# Description

This pr adds npm download metrics per package [taken from npm download count api](https://github.com/npm/registry/blob/master/docs/download-counts.md), for each celo package per day and sends them to prometheus for ingestion into grafana. This adds a new metric declaration and functionality to collect different metric types.

In addition, the code is refactored somewhat

* Extracted npm / socket logic into discrete files
* Modified control flow to add explicit init step
* Some logging changes
* Created a metric type def to prevent using `map[string]interface{}` everywhere

# Example Prometheus output

```
# HELP npm_download_count NPM package download count for a given day
# TYPE npm_download_count gauge
npm_download_count{date="2024-02-18",package="@celo/wallet-remote"} 180
npm_download_count{date="2024-02-18",package="@celo/wallet-rpc"} 12
# HELP socket_score Shows socket.dev packages scores
# TYPE socket_score gauge
socket_score{package="@celo/wallet-remote",score="license",version="5.1.2"} 0.8674955154068579
socket_score{package="@celo/wallet-remote",score="maintenance",version="5.1.2"} 0.6597539553864471
socket_score{package="@celo/wallet-remote",score="miscellaneous",version="5.1.2"} 0
socket_score{package="@celo/wallet-remote",score="quality",version="5.1.2"} 0.47630445736698557
socket_score{package="@celo/wallet-remote",score="supplychainrisk",version="5.1.2"} 0.3774902325656003
socket_score{package="@celo/wallet-remote",score="vulnerability",version="5.1.2"} 0.5
socket_score{package="@celo/wallet-rpc",score="license",version="5.1.2"} 0.8674955154068579
socket_score{package="@celo/wallet-rpc",score="maintenance",version="5.1.2"} 0.6597539553864471
socket_score{package="@celo/wallet-rpc",score="miscellaneous",version="5.1.2"} 0
socket_score{package="@celo/wallet-rpc",score="quality",version="5.1.2"} 0.4891786926458545
socket_score{package="@celo/wallet-rpc",score="supplychainrisk",version="5.1.2"} 0.2998454968631518
socket_score{package="@celo/wallet-rpc",score="vulnerability",version="5.1.2"} 0.5
```

# Tested

* Tested locally
* Tested on integration-tests cluster (with dev image)

# Tickets

* relates to https://github.com/celo-org/celo-labs/issues/1059